### PR TITLE
Separated out logging and stats endpoints

### DIFF
--- a/src/main/java/cpsc/dlsproject/Interpreter.java
+++ b/src/main/java/cpsc/dlsproject/Interpreter.java
@@ -32,7 +32,8 @@ public class Interpreter {
     try {
       program = (Program) parser.run();
     } catch (Exception e) {
-      System.out.println("Throwing a parsing exception!");
+      System.out.println("Throwing a parsing exception!: ");
+      e.printStackTrace();
       throw new InterpreterException(e);
     }
 

--- a/src/main/java/cpsc/dlsproject/binary.dsl
+++ b/src/main/java/cpsc/dlsproject/binary.dsl
@@ -5,21 +5,21 @@ GET "/" {
   VAR c: Boolean = true;
   VAR d: Boolean = false;
 
-  VAR addition: Number = a + b;
-  VAR subtraction: Number = a - b;
-  VAR multiplication: Number = a * b;
-  VAR division: Number = a \ b;
-  VAR andOp: Boolean = c & d;
-  VAR orOp: Boolean = d | d;
-  VAR lessThanOp: Boolean = a < b;
-  VAR lessThanOrEqualOp: Boolean = a <= b;
-  VAR equalOp: Boolean = a == b;
-  VAR notEqualOp: Boolean = a != b;
-  VAR greaterThanOp: Boolean = a > b;
-  VAR greaterOp: Boolean = a >= b;
+  VAR addition: Number = + a TO b;
+  VAR subtraction: Number = - a TO b;
+  VAR multiplication: Number = * a TO b;
+  VAR division: Number = \ a TO b;
+  VAR andOp: Boolean = && c TO d;
+  VAR orOp: Boolean = || c TO d;
+  VAR lessThanOp: Boolean = < a TO b;
+  VAR lessThanOrEqualOp: Boolean = <= a TO b;
+  VAR equalOp: Boolean = == a TO b;
+  VAR notEqualOp: Boolean = != a TO b;
+  VAR greaterThanOp: Boolean = > a TO b;
+  VAR greaterOp: Boolean = >= a TO b;
 
   SEND {
-  "addition: {addition}, subtraction: {subtraction}, multiplication: {multiplication}, division: {division}, andOp: {andOp}, orOp: {orOp}, lessThanOp: {lessThanOp}, lessThanOrEqualOp: {lessThanOrEqualOp}, equalOp: {equalOp}, notEqualOp: {notEqualOp}, greaterThanOp: {greaterThanOp}, greaterOp: {greaterOp}";
   200;
+  "addition: {addition}, subtraction: {subtraction}, multiplication: {multiplication}, division: {division}, andOp: {andOp}, orOp: {orOp}, lessThanOp: {lessThanOp}, lessThanOrEqualOp: {lessThanOrEqualOp}, equalOp: {equalOp}, notEqualOp: {notEqualOp}, greaterThanOp: {greaterThanOp}, greaterOp: {greaterOp}";
   }
-};
+}

--- a/src/main/java/cpsc/dlsproject/conditional.dsl
+++ b/src/main/java/cpsc/dlsproject/conditional.dsl
@@ -1,7 +1,7 @@
 GET "/conditionalTrue" {
     VAR a : Number = 1;
     VAR b : Number = 2;
-    IF (a < b) {
+    IF (< a TO b) {
       SEND {
         200;
         "something good";
@@ -17,7 +17,7 @@ GET "/conditionalTrue" {
 GET "/conditionalFalse" {
     VAR a : Number = 1;
     VAR b : Number = 2;
-    IF (a > b) {
+    IF (> a TO b) {
       SEND {
         200;
         "something good";

--- a/src/main/java/cpsc/dlsproject/server/Server.java
+++ b/src/main/java/cpsc/dlsproject/server/Server.java
@@ -1,24 +1,26 @@
 package cpsc.dlsproject.server;
 
 import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 
-import javax.annotation.processing.SupportedSourceVersion;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.time.LocalDateTime;
+import java.util.*;
 
 public final class Server {
   private final int port;
   private final HttpServer server;
   private final Map<String, HttpContext> endpointMap;
   private final Map<String, Integer> endpointVisitFrequency;
+  private final JSONArray serverLogsArray;
   private final Set<String> reservedEndpoints;
+  private final String statsApiEndpoint = "/stats";
   private final String loggingApiEndpoint = "/logs";
 
   private Server(int port) throws IOException {
@@ -27,6 +29,8 @@ public final class Server {
     endpointMap = new HashMap<>();
     endpointVisitFrequency = new HashMap<>();
     reservedEndpoints = new HashSet<>();
+    serverLogsArray = new JSONArray();
+    reservedEndpoints.add(statsApiEndpoint);
     reservedEndpoints.add(loggingApiEndpoint);
   }
 
@@ -44,7 +48,11 @@ public final class Server {
     this.server.stop(0);
   }
 
-  public String getLoggingEndpointUrl() {
+  public String getStatsApiEndpoint() {
+    return statsApiEndpoint;
+  }
+
+  public String getLoggingApiEndpoint() {
     return loggingApiEndpoint;
   }
 
@@ -79,14 +87,19 @@ public final class Server {
     return new Builder();
   }
 
-  public void setupLoggingEndpoint() {
+  /** Sets up the endpoint that displays stats for the current run of the server enpoints */
+  public void setupStatsEndpoint() {
     HttpHandler handler =
         (httpExchange) -> {
-          this.increaseEndpointHitFrequency(this.getLoggingEndpointUrl());
+          this.increaseEndpointHitFrequency(this.getStatsApiEndpoint());
           StringBuilder response = new StringBuilder();
           Set<Map.Entry<String, Integer>> frequencySet = this.getEndpointFrequencyEntrySet();
           for (Map.Entry<String, Integer> entry : frequencySet) {
-            response.append(entry.getKey()).append(":").append(entry.getValue()).append(System.getProperty("line.separator"));
+            response
+                .append(entry.getKey())
+                .append(":")
+                .append(entry.getValue())
+                .append(System.getProperty("line.separator"));
           }
           httpExchange.getResponseHeaders().add("Content-Type", "text/html; charset=UTF-8");
           httpExchange.sendResponseHeaders(200, response.length());
@@ -94,11 +107,25 @@ public final class Server {
           out.write(response.toString().getBytes());
           out.close();
         };
-    this.endpointMap.put(
-        this.loggingApiEndpoint, this.server.createContext(this.loggingApiEndpoint));
-    this.setHandler(this.getLoggingEndpointUrl(), handler);
+    this.endpointMap.put(this.statsApiEndpoint, this.server.createContext(this.statsApiEndpoint));
+    this.setHandler(this.getStatsApiEndpoint(), handler);
     System.out.println("Set handler for logging");
-    this.endpointVisitFrequency.put(this.loggingApiEndpoint, 0);
+    this.endpointVisitFrequency.put(this.statsApiEndpoint, 0);
+  }
+
+  /** Sets up the endpoint that displays the logs */
+  public void setupLoggingEndpoint() {
+    HttpHandler handler = (httpExchange) -> {
+      httpExchange.getResponseHeaders().add("Content-Type", "text/html; charset=UTF-8");
+      httpExchange.sendResponseHeaders(200, serverLogsArray.toJSONString().length());
+      OutputStream out = httpExchange.getResponseBody();
+      out.write(serverLogsArray.toJSONString().getBytes());
+      out.close();
+    };
+    this.endpointMap.put(this.loggingApiEndpoint, this.server.createContext(this.loggingApiEndpoint));
+    this.setHandler(this.getLoggingApiEndpoint(), handler);
+    System.out.println("Set handler for logging");
+    this.endpointVisitFrequency.put(this.getLoggingApiEndpoint(), 0);
   }
 
   /** Increase the frequency hit of the endpoint */
@@ -107,6 +134,15 @@ public final class Server {
       throw new IllegalArgumentException("Frequency increasing method: Endpoint does not exist");
     }
     endpointVisitFrequency.put(endpoint, endpointVisitFrequency.get(endpoint) + 1);
+  }
+
+  /** Add to server logs */
+  public void addToServerLogs(HttpExchange httpExchange) {
+    JSONObject object = new JSONObject();
+    object.put("path", httpExchange.getHttpContext().getPath());
+    object.put("client_ip", httpExchange.getRemoteAddress().getAddress().toString());
+    object.put("log_time", LocalDateTime.now().toString());
+    serverLogsArray.add(object);
   }
 
   /** Returns endpoint entry set */

--- a/src/main/java/cpsc/dlsproject/server/Server.java
+++ b/src/main/java/cpsc/dlsproject/server/Server.java
@@ -136,12 +136,13 @@ public final class Server {
     endpointVisitFrequency.put(endpoint, endpointVisitFrequency.get(endpoint) + 1);
   }
 
-  /** Add to server logs */
-  public void addToServerLogs(HttpExchange httpExchange) {
+  /** Add to server logs. The done field is true if the request has been finished */
+  public void addToServerLogs(HttpExchange httpExchange, boolean done) {
     JSONObject object = new JSONObject();
     object.put("path", httpExchange.getHttpContext().getPath());
     object.put("client_ip", httpExchange.getRemoteAddress().getAddress().toString());
     object.put("log_time", LocalDateTime.now().toString());
+    object.put("done", done);
     serverLogsArray.add(object);
   }
 

--- a/src/main/java/cpsc/dlsproject/visitors/ParseVisitor.java
+++ b/src/main/java/cpsc/dlsproject/visitors/ParseVisitor.java
@@ -125,6 +125,7 @@ public class ParseVisitor extends ASTVisitor<BaseAST> {
                     break;
 
                 default:
+                    System.out.println("UNMATCHED: " + tokenizer.checkCurrent());
                     throw new Exception("Invalid statement in body of endpoint declaration.");
             }
             if (tokenizer.checkCurrent().equals(";")) {

--- a/src/main/java/cpsc/dlsproject/visitors/ServerBuilderVisitor.java
+++ b/src/main/java/cpsc/dlsproject/visitors/ServerBuilderVisitor.java
@@ -69,7 +69,7 @@ public class ServerBuilderVisitor extends ASTVisitor<Value> {
           // Setup environment for execution.
           variables.setHttpExchange(httpExchange);
           server.increaseEndpointHitFrequency(endpoint.url.url);
-          server.addToServerLogs(httpExchange);
+          server.addToServerLogs(httpExchange, false /* done */);
           for (Statement statement : endpoint.statements) {
             try {
               this.visit(statement);
@@ -85,7 +85,7 @@ public class ServerBuilderVisitor extends ASTVisitor<Value> {
           }
 
           // Tear down environment after execution.
-          server.addToServerLogs(httpExchange);
+          server.addToServerLogs(httpExchange, true /* done */);
           variables.clearHttpExchange();
         });
 

--- a/src/main/java/cpsc/dlsproject/visitors/ServerBuilderVisitor.java
+++ b/src/main/java/cpsc/dlsproject/visitors/ServerBuilderVisitor.java
@@ -40,6 +40,7 @@ public class ServerBuilderVisitor extends ASTVisitor<Value> {
       server = Server.newBuilder().setPort(port).build();
       variables = new SymbolTable();
       this.visit(program);
+      server.setupStatsEndpoint();
       server.setupLoggingEndpoint();
       server.startServer();
       System.out.println("Server is serving in port " + port);
@@ -68,6 +69,7 @@ public class ServerBuilderVisitor extends ASTVisitor<Value> {
           // Setup environment for execution.
           variables.setHttpExchange(httpExchange);
           server.increaseEndpointHitFrequency(endpoint.url.url);
+          server.addToServerLogs(httpExchange);
           for (Statement statement : endpoint.statements) {
             try {
               this.visit(statement);
@@ -83,6 +85,7 @@ public class ServerBuilderVisitor extends ASTVisitor<Value> {
           }
 
           // Tear down environment after execution.
+          server.addToServerLogs(httpExchange);
           variables.clearHttpExchange();
         });
 


### PR DESCRIPTION
This PR does the following things:

1. Separated out the endpoint for spitting out logs. Dynamic logs are now generated in the "/logs" endpoint that can be used by the visualising frontend to consume and make sense of. Every request logs twice, once before the request is processed, and once after. Currently, the request's endpoint path, client IP and the time of creation is logged.
2. Created the "/stats" endpoint, that will output all the data that is processed on the server side. Right now, it only outputs the number of API calls to each endpoint currently running.
3. Fixed the language samples in the main directory to incorporate latest language changes from Changelist 1.0.0.