### PR TITLE
Improvements to server logs

### DIFF
--- a/src/main/java/cpsc/dlsproject/server/Server.java
+++ b/src/main/java/cpsc/dlsproject/server/Server.java
@@ -22,7 +22,7 @@ public final class Server {
   private final Set<String> reservedEndpoints;
   private final String statsApiEndpoint = "/_stats";
   private final String loggingApiEndpoint = "/_logs";
-  private volatile int id;
+  private volatile long id;
 
   private Server(int port) throws IOException {
     this.port = port;
@@ -139,7 +139,7 @@ public final class Server {
   }
 
   /** Increment and get the ID of the request */
-  public int incrementAndGetID() {
+  public long incrementAndGetID() {
     return ++id;
   }
 

--- a/src/main/java/cpsc/dlsproject/server/Server.java
+++ b/src/main/java/cpsc/dlsproject/server/Server.java
@@ -20,8 +20,9 @@ public final class Server {
   private final Map<String, Integer> endpointVisitFrequency;
   private final JSONArray serverLogsArray;
   private final Set<String> reservedEndpoints;
-  private final String statsApiEndpoint = "/stats";
-  private final String loggingApiEndpoint = "/logs";
+  private final String statsApiEndpoint = "/_stats";
+  private final String loggingApiEndpoint = "/_logs";
+  private volatile int id;
 
   private Server(int port) throws IOException {
     this.port = port;
@@ -32,6 +33,7 @@ public final class Server {
     serverLogsArray = new JSONArray();
     reservedEndpoints.add(statsApiEndpoint);
     reservedEndpoints.add(loggingApiEndpoint);
+    id = 0;
   }
 
   /** Starts a given server */
@@ -136,13 +138,19 @@ public final class Server {
     endpointVisitFrequency.put(endpoint, endpointVisitFrequency.get(endpoint) + 1);
   }
 
+  /** Increment and get the ID of the request */
+  public int incrementAndGetID() {
+    return ++id;
+  }
+
   /** Add to server logs. The done field is true if the request has been finished */
-  public void addToServerLogs(HttpExchange httpExchange, boolean done) {
+  public void addToServerLogs(HttpExchange httpExchange, boolean done, long id) {
     JSONObject object = new JSONObject();
     object.put("path", httpExchange.getHttpContext().getPath());
     object.put("client_ip", httpExchange.getRemoteAddress().getAddress().toString());
     object.put("log_time", LocalDateTime.now().toString());
     object.put("done", done);
+    object.put("id", id);
     serverLogsArray.add(object);
   }
 

--- a/src/main/java/cpsc/dlsproject/server/Server.java
+++ b/src/main/java/cpsc/dlsproject/server/Server.java
@@ -23,6 +23,7 @@ public final class Server {
   private final String statsApiEndpoint = "/_stats";
   private final String loggingApiEndpoint = "/_logs";
   private volatile long id;
+  private volatile long logId;
 
   private Server(int port) throws IOException {
     this.port = port;
@@ -34,6 +35,7 @@ public final class Server {
     reservedEndpoints.add(statsApiEndpoint);
     reservedEndpoints.add(loggingApiEndpoint);
     id = 0;
+    logId = 0;
   }
 
   /** Starts a given server */
@@ -143,14 +145,37 @@ public final class Server {
     return ++id;
   }
 
-  /** Add to server logs. The done field is true if the request has been finished */
-  public void addToServerLogs(HttpExchange httpExchange, boolean done, long id) {
+  /** Get current ID */
+  public long getCurrentId() {
+    return this.id;
+  }
+
+  /** Add request to server logs */
+  public void addRequestToServerLogs(HttpExchange httpExchange, long id) {
     JSONObject object = new JSONObject();
     object.put("path", httpExchange.getHttpContext().getPath());
     object.put("client_ip", httpExchange.getRemoteAddress().getAddress().toString());
     object.put("log_time", LocalDateTime.now().toString());
-    object.put("done", done);
+    object.put("type", "request");
     object.put("id", id);
+    object.put("log_id", this.logId);
+    ++logId;
+    serverLogsArray.add(object);
+  }
+
+  /** Add response to server logs */
+  public void addResponseToServerLogs(HttpExchange httpExchange, int statusCode, String responseMessage, String contentType, long id) {
+    JSONObject object = new JSONObject();
+    object.put("path", httpExchange.getHttpContext().getPath());
+    object.put("client_ip", httpExchange.getRemoteAddress().getAddress().toString());
+    object.put("log_time", LocalDateTime.now().toString());
+    object.put("type", "response");
+    object.put("id", id);
+    object.put("status_code", statusCode);
+    object.put("response_message", responseMessage);
+    object.put("content_type", contentType);
+    object.put("log_id", logId);
+    ++logId;
     serverLogsArray.add(object);
   }
 

--- a/src/main/java/cpsc/dlsproject/visitors/ServerBuilderVisitor.java
+++ b/src/main/java/cpsc/dlsproject/visitors/ServerBuilderVisitor.java
@@ -69,7 +69,8 @@ public class ServerBuilderVisitor extends ASTVisitor<Value> {
           // Setup environment for execution.
           variables.setHttpExchange(httpExchange);
           server.increaseEndpointHitFrequency(endpoint.url.url);
-          server.addToServerLogs(httpExchange, false /* done */);
+          int id = server.incrementAndGetID();
+          server.addToServerLogs(httpExchange, false /* done */, id);
           for (Statement statement : endpoint.statements) {
             try {
               this.visit(statement);
@@ -85,7 +86,7 @@ public class ServerBuilderVisitor extends ASTVisitor<Value> {
           }
 
           // Tear down environment after execution.
-          server.addToServerLogs(httpExchange, true /* done */);
+          server.addToServerLogs(httpExchange, true /* done */, id);
           variables.clearHttpExchange();
         });
 

--- a/src/main/java/cpsc/dlsproject/visitors/ServerBuilderVisitor.java
+++ b/src/main/java/cpsc/dlsproject/visitors/ServerBuilderVisitor.java
@@ -69,7 +69,7 @@ public class ServerBuilderVisitor extends ASTVisitor<Value> {
           // Setup environment for execution.
           variables.setHttpExchange(httpExchange);
           server.increaseEndpointHitFrequency(endpoint.url.url);
-          int id = server.incrementAndGetID();
+          long id = server.incrementAndGetID();
           server.addToServerLogs(httpExchange, false /* done */, id);
           for (Statement statement : endpoint.statements) {
             try {

--- a/src/main/java/cpsc/dlsproject/visitors/ServerBuilderVisitor.java
+++ b/src/main/java/cpsc/dlsproject/visitors/ServerBuilderVisitor.java
@@ -13,7 +13,7 @@ import cpsc.dlsproject.utils.Utils;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 /** A class representing a visitor for building the server. */
@@ -70,23 +70,24 @@ public class ServerBuilderVisitor extends ASTVisitor<Value> {
           variables.setHttpExchange(httpExchange);
           server.increaseEndpointHitFrequency(endpoint.url.url);
           long id = server.incrementAndGetID();
-          server.addToServerLogs(httpExchange, false /* done */, id);
+          server.addRequestToServerLogs(httpExchange, id);
           for (Statement statement : endpoint.statements) {
             try {
               this.visit(statement);
             } catch (Exception e) {
+              String errorMessage = "Sorry, there has been an error on the server side. :(";
               httpExchange
                   .getResponseBody()
                   .write(
-                      "Sorry, there has been an error on the server side. :("
-                          .getBytes(Charset.forName("UTF-8")));
+                      errorMessage
+                          .getBytes(StandardCharsets.UTF_8));
               System.out.println(
                   "500: There is an error when evaluating the statement. It is more likely to be the interpreter's error, not the developer's.");
+              server.addResponseToServerLogs(httpExchange, 500, errorMessage, "text/html", id);
             }
           }
 
           // Tear down environment after execution.
-          server.addToServerLogs(httpExchange, true /* done */, id);
           variables.clearHttpExchange();
         });
 
@@ -142,6 +143,7 @@ public class ServerBuilderVisitor extends ASTVisitor<Value> {
       OutputStream out = httpExchange.getResponseBody();
       out.write(body);
       out.close();
+      server.addResponseToServerLogs(httpExchange, response.statusCode, response.message, "text/html" /* ContentType */, server.getCurrentId());
     } catch (IOException e) {
       throw new ServerEvaluationError("There is an error when writing response into body.");
     }


### PR DESCRIPTION
This PR does the following things:

1. Separated out request and response logs. Both log objects have different fields now.
2. Added "content_type", "response_status", "response_message" fields to the response log
3. Replaced the "done" field with "type" field which identifies the type of log (request or response)
4. Added "id" field to the server logs. Every request-response pair of logs will have the same "id".
5. Added "log_id "field, which uniquely identifies every log, irrespective of it being a request/response log.