### PR TITLE
Dev package.json fix

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,7 @@
   "name": "client",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:8000",
   "dependencies": {
     "react": "^16.11.0",
     "react-dom": "^16.11.0",


### PR DESCRIPTION
The package.json file was missing the proxy field, which was the root cause of failing API calls to the backend.